### PR TITLE
drop unncessary including of servermd.h

### DIFF
--- a/src/s3v_accel.c
+++ b/src/s3v_accel.c
@@ -36,8 +36,6 @@ in this Software without prior written authorization from the XFree86 Project.
 	/* fb includes are in s3v.h */
 #include "xaarop.h"
 
-#include "servermd.h" /* LOG2_BYTES_PER_SCANLINE_PAD */
-
 static void S3VNopAllCmdSets(ScrnInfoPtr pScrn);
 
 Bool 

--- a/src/s3v_shadow.c
+++ b/src/s3v_shadow.c
@@ -62,7 +62,6 @@ in this Software without prior written authorization from the XFree86 Project.
 #include "xf86_OSproc.h"
 #include "xf86Pci.h"
 #include "shadowfb.h"
-#include "servermd.h"
 #include "s3v.h"
 
 


### PR DESCRIPTION
Don't need anything from that header, so no need to include it.